### PR TITLE
Use byte length instead of character count

### DIFF
--- a/src/Service/MinifyService.php
+++ b/src/Service/MinifyService.php
@@ -26,7 +26,7 @@ class MinifyService
 
         if ($shouldAddCompressionHeader) {
             $startTime = microtime(true);
-            $lengthInitialContent = mb_strlen($content, 'utf8');
+            $lengthInitialContent = strlen($content);
 
             if ($lengthInitialContent === 0) {
                 return '';
@@ -143,7 +143,7 @@ class MinifyService
 
     private function assignCompressionHeader(?ResponseHeaderBag $headerBag, string $content, int $lengthInitialContent, float $startTime): void
     {
-        $lengthContent = mb_strlen($content, 'utf8');
+        $lengthContent = strlen($content);
 
         if ($lengthContent === 0) {
             return;


### PR DESCRIPTION
Makes more sense to know the number of bytes that were saved rather than the number of characters, and since PHP strings store their length, it's a much faster operation.